### PR TITLE
Fixed Buffer-to-String conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ const getServiceWorker = ({ outDir, customOptions = {}, rootDir }) => {
     })
 }
 
-
 module.exports = bundler => {
     const { rootDir, outDir } = bundler.options
     distDir = outDir.replace(rootDir, '').substr(1)
@@ -47,9 +46,11 @@ module.exports = bundler => {
             }
 
             if (customOptions.swSrc) {
-                codes += UglifyJS.minify(readFileSync(path.join(rootDir, customOptions.swSrc)))
+                codes += UglifyJS.minify(readFileSync(path.join(rootDir, customOptions.swSrc), 'utf8')).code
             }
+
             writeFileSync(serviceWorkerFilePath, codes)
+
             console.log(`😁 Service worker "${distDir}/${customOptions.fileName}" generated successfully.`)
         }).catch(err => {
             console.log(`🤯 Service worker generation failed: ${err}`)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-plugin-sw-precache2",
   "description": "Another Parcel plugin for service-worker with full `sw-precache` configurations support.",
   "keywords": "parcel, parcel-plugin, sw-precache, service-worker, sw, precache, pwa, offline",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "index.js",
   "author": "leafiy <t@leafiy.com>",
   "contributors": [


### PR DESCRIPTION
The code from swSrc wasn't added to the service worker because I forgot to convert the Buffer into a string.

Now it's fixed.